### PR TITLE
update syslog slug regex

### DIFF
--- a/haproxy/haproxy_logline.py
+++ b/haproxy/haproxy_logline.py
@@ -24,8 +24,8 @@ SYSLOG_REGEX = re.compile(
     # 13:01:26
     r'\d+:\d+:\d+\s+'
     # localhost haproxy[28029]:
-    # note that can be either localhost or an IP
-    r'(\w+|(\d+\.){3}\d+)\s+\w+\[\d+\]:\s+',
+    # note that can be either localhost or an IP or a hostname
+    r'(\w+|(\d+\.){3}\d+|[a-zA-Z0-9_-]+)\s+\w+\[\d+\]:\s+',
 
 )
 

--- a/haproxy/tests/test_haproxy_log_line.py
+++ b/haproxy/tests/test_haproxy_log_line.py
@@ -212,3 +212,14 @@ class HaproxyLogLineTest(unittest.TestCase):
 
         self.assertTrue(log_line.valid)
         self.assertEqual('/', log_line.http_request_path)
+
+    def test_haproxy_log_line_strip_syslog_valid_hostname_slug(self):
+        """Checks that if the hostname added to syslog slug is still valid
+        line
+        """
+        self.http_request = 'GET / HTTP/1.1'
+        self.process_name_and_pid = 'ip-192-168-1-1 haproxy[28029]:'
+        raw_line = self._build_test_string()
+        log_line = HaproxyLogLine(raw_line)
+
+        self.assertTrue(log_line.valid)


### PR DESCRIPTION
I was using your niffy utility to parse my haproxy logs. However, I couldn't get any lines processed because my haproxy slug had a hostname (server has an updated hosts file with '-') instead of localhost/IP. 

Here's a relevant snip of the [man 5 hosts](http://man7.org/linux/man-pages/man5/hosts.5.html) 
> Host names may contain only alphanumeric characters, minus signs ("-"), and periods ("."). 

Added a unittest too. 
Thanks for the utility,
Cheers, 
- d.c.