### PR TITLE
Support status code for terminated requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ CHANGES
 1.3 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Support -1 as a status_code
+  [Christopher Baines]
 
 
 1.2 (2015-12-07)

--- a/haproxy/haproxy_logline.py
+++ b/haproxy/haproxy_logline.py
@@ -40,7 +40,7 @@ HAPROXY_LINE_REGEX = re.compile(
     r'(?P<tq>-?\d+)/(?P<tw>-?\d+)/(?P<tc>-?\d+)/'
     r'(?P<tr>-?\d+)/(?P<tt>\+?\d+)\s+'
     # 200 83285
-    r'(?P<status_code>\d+)\s+(?P<bytes_read>\+?\d+)\s+'
+    r'(?P<status_code>-?\d+)\s+(?P<bytes_read>\+?\d+)\s+'
     # - - ----
     r'.*\s+'  # ignored by now, should capture cookies and termination state
     # 87/87/87/1/0

--- a/haproxy/tests/test_regex.py
+++ b/haproxy/tests/test_regex.py
@@ -132,6 +132,17 @@ class HaproxyLogLineRegexTest(unittest.TestCase):
         self.assertEqual(matches.group('status_code'), status)
         self.assertEqual(matches.group('bytes_read'), bytes_read)
 
+    def test_line_regex_status_and_bytes_for_terminated_request(self):
+        status = '-1'
+        bytes_read = '0'
+        self.status_and_bytes = '{0} {1}'.format(status, bytes_read)
+
+        log_line = self._build_test_string()
+        matches = HAPROXY_LINE_REGEX.match(log_line)
+
+        self.assertEqual(matches.group('status_code'), status)
+        self.assertEqual(matches.group('bytes_read'), bytes_read)
+
     def test_line_regex_connections_and_retries(self):
         act = '40'
         fe = '10'


### PR DESCRIPTION
Thanks for writing this library and releasing it as free software :) I have just started using it, and noticed that there are some failed requests that it fails to parse.

The 1.6 documentation for HAProxy is pretty open about the values to expect in the status_code field:
```
  - "status_code" is the HTTP status code returned to the client. This status
    is generally set by the server, but it might also be set by haproxy when
    the server cannot be reached or when its response is blocked by haproxy.
```