### PR TITLE
Improve performance of cmd_print

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ CHANGES
 2.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Improve performance for ``cmd_print``.
+  [kevinjqiu]
 
 2.0.1 (2016-10-29)
 ------------------

--- a/haproxy/logfile.py
+++ b/haproxy/logfile.py
@@ -82,7 +82,6 @@ class Log(object):
         """
 
         for line in logfile:
-            self.total_lines += 1
             stripped_line = line.strip()
             parsed_line = Line(stripped_line)
 
@@ -90,6 +89,7 @@ class Log(object):
                 self._valid_lines.append(parsed_line)
             else:
                 self._invalid_lines.append(stripped_line)
+        self.total_lines = len(self._valid_lines) + len(self._invalid_lines)
 
     def filter(self, filter_func, reverse=False):
         """Filter current log lines by a given filter function.
@@ -385,7 +385,9 @@ class Log(object):
 
     def cmd_print(self):
         """Returns the raw lines to be printed."""
-        return '\n'.join([line.raw_line for line in self._valid_lines])
+        if not self._valid_lines:
+            return ''
+        return '\n'.join([line.raw_line for line in self._valid_lines]) + '\n'
 
     def _sort_lines(self):
         """Haproxy writes its logs after having gathered all information

--- a/haproxy/logfile.py
+++ b/haproxy/logfile.py
@@ -385,12 +385,7 @@ class Log(object):
 
     def cmd_print(self):
         """Returns the raw lines to be printed."""
-        data = ''
-        for line in self._valid_lines:
-            data += line.raw_line
-            data += '\n'
-
-        return data
+        return '\n'.join([line.raw_line for line in self._valid_lines])
 
     def _sort_lines(self):
         """Haproxy writes its logs after having gathered all information


### PR DESCRIPTION
My log file has about 25k log entries after filtering. With the previous
implementation, `cmd_print` hangs for a long time with CPU at 100%.

Using for loop and concate a string is expensive, since the previous
`data` object is thrown away and may get GC'ed.

Switched to a list comprehension and this function finished in 0.01
second (on pypy, haven't tested it on cpython).