### PR TITLE
make ip_counter use client_ip per default. 

### DIFF
--- a/haproxy/line.py
+++ b/haproxy/line.py
@@ -165,10 +165,12 @@ class Line(object):
         return False
 
     def get_ip(self):
-        """Returns the IP provided on the log line."""
+        """Returns the IP provided on the log line, or the client_ip if absent/empty."""
         if self.captured_request_headers is not None:
-            return self.captured_request_headers[1:-1]
-        return None
+            ip = self.captured_request_headers[1:-1].split('|')[0]
+            if ip:
+                return ip
+        return self.client_ip
 
     def _parse_line(self, line):
         # remove syslog slug if found

--- a/haproxy/logfile.py
+++ b/haproxy/logfile.py
@@ -161,17 +161,10 @@ class Log(object):
 
     def cmd_ip_counter(self):
         """Reports a breakdown of how many requests have been made per IP.
-
-        .. note::
-          To enable this command requests need to provide a header with the
-          forwarded IP (usually X-Forwarded-For) and be it the only header
-          being captured.
         """
         ip_counter = defaultdict(int)
         for line in self._valid_lines:
-            ip = line.get_ip()
-            if ip is not None:
-                ip_counter[ip] += 1
+            ip_counter[line.get_ip()] += 1
         return ip_counter
 
     def cmd_top_ips(self):

--- a/haproxy/tests/test_log_file.py
+++ b/haproxy/tests/test_log_file.py
@@ -94,7 +94,8 @@ class LogFileTest(unittest.TestCase):
         )
         ip_counter = log_file.cmd_ip_counter()
 
-        self.assertEqual(len(ip_counter), 4)
+        self.assertEqual(len(ip_counter), 5)
+        self.assertEqual(ip_counter['127.0.0.1'], 1)
         self.assertEqual(ip_counter['123.123.123.123'], 4)
         self.assertEqual(ip_counter['123.123.124.124'], 2)
         self.assertEqual(ip_counter['123.123.124.123'], 1)


### PR DESCRIPTION
Allow to be the first of multiple captured headers.