### PR TITLE
Update filters.py

### DIFF
--- a/haproxy/filters.py
+++ b/haproxy/filters.py
@@ -45,7 +45,9 @@ def filter_path(path):
     """
 
     def filter_func(log_line):
-        return path in log_line.http_request_path
+        http_request_path = log_line.http_request_path
+        if http_request_path:
+            return path in log_line.http_request_path
 
     return filter_func
 


### PR DESCRIPTION
Some log lines don't contain a 'path' field, so filter_path fails when it is used. Checking the value first prevents it from bailing out.