### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
+os: linux
+arch:
+ - amd64
+ - ppc64le
 language: python
 sudo: false
 env:
@@ -11,6 +15,11 @@ matrix:
     - python: "3.7"
       env:
         - QA="true"
+    - python: "3.7"
+      env:
+        - QA="true"
+      arch: ppc64le  
+    
 cache: pip
 install:
   - pip install -r requirements-dev.txt


### PR DESCRIPTION
Thank you for the code.
Add support for architecture ppc64le.  
This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing. For more info tag @gerrith3
