### PR TITLE
[FIX] Remove end of line

### DIFF
--- a/haproxy/line.py
+++ b/haproxy/line.py
@@ -38,7 +38,6 @@ HAPROXY_LINE_REGEX = re.compile(
     r'({(?P<request_headers>.*)}\s+{(?P<response_headers>.*)}\s+|{(?P<headers>.*)}\s+|)'
     # "GET /path/to/image HTTP/1.1"
     r'"(?P<http_request>.*)"'
-    r'\Z'  # end of line
 )
 
 HTTP_REQUEST_REGEX = re.compile(


### PR DESCRIPTION
Allow users to add custom fields to logs at the end of the line and still using haproxy_log_analysis.

Line Example adding encrypt and protocol at the end:
Dec 18 13:29:38 localhost haproxy[103935]: 45.163.31.4:48486 [18/Dec/2020:13:29:38.458] xxxx~ xxxxx/xxxxx-prd 0/0/1/312/313 200 624 - - ---- 5/5/3/1/0 0/0 {172.30.2.172|604||} {Restlet-Framework/2.2.3|473|||} "POST /CustomEndpoint/Endpoint HTTP/1.1" ECDHE-RSA-AES256-SHA384 TLSv1.2