### PR TITLE
feat(line): only get first IP

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ CHANGES
 5.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Only get the first IP from `X-Forwarded-For` header.
+  [gforcada]
 
 5.0.0 (2022-11-27)
 ------------------

--- a/haproxy/line.py
+++ b/haproxy/line.py
@@ -165,7 +165,9 @@ class Line:
         if self.captured_request_headers is not None:
             ip = self.captured_request_headers.split('|')[0]
             if ip:
-                return ip
+                # only get the first IP, if there are more usually
+                # are the intermediate servers
+                return ip.split(',')[0]
         return self.client_ip
 
     def _parse_line(self, line):

--- a/haproxy/tests/test_log_line.py
+++ b/haproxy/tests/test_log_line.py
@@ -170,6 +170,16 @@ def test_ip_from_headers(line_factory):
 
 @pytest.mark.parametrize(
     'ip',
+    ['1.2.3.4', '1.2.3.4, 2.3.4.5', '1.2.3.4,2.3.4.5,5.4.3.2'],
+)
+def test_only_first_ip_from_headers(line_factory, ip):
+    """Check that if there are multiple IPs, only the first one is used."""
+    line = line_factory(headers=f' {{{ip}}}')
+    assert line.ip == '1.2.3.4'
+
+
+@pytest.mark.parametrize(
+    'ip',
     ['127.1.2.7', '1.127.230.47', 'fe80::9379:c29e:6701:cef8', 'fe80::9379:c29e::'],
 )
 def test_ip_from_client_ip(line_factory, ip):


### PR DESCRIPTION
If one enables the `X-Forwarded-For` header, all servers that see this header append the IP of their incoming connection..

Usually this intermediate servers are not interesting, only the out most one is.