### PR TITLE
Flip wait_on_queues filter logic

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,11 @@ CHANGES
   with ready to use examples.
   [gforcada]
 
+- Switch logic of `wait_on_queues` filter,
+  count lines that are above the filter,
+  e.g. the lines that took more than the specified time.
+  [gforcada]
+
 5.1.0 (2022-12-03)
 ------------------
 

--- a/haproxy/filters.py
+++ b/haproxy/filters.py
@@ -85,7 +85,7 @@ def filter_wait_on_queues(max_waiting):
 
     def filter_func(log_line):
         waiting = int(max_waiting)
-        return waiting >= log_line.time_wait_queues
+        return waiting <= log_line.time_wait_queues
 
     return filter_func
 

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -79,7 +79,7 @@ def test_filter_slow_requests(line_factory, tr, result):
     assert current_filter(line) is result
 
 
-@pytest.mark.parametrize('tw, result', [(45, True), (13000, False), (4566, False)])
+@pytest.mark.parametrize('tw, result', [(45, False), (13000, True), (4566, True)])
 def test_filter_wait_on_queues(line_factory, tw, result):
     """Check that filter_wait_on_queues filter works as expected"""
     current_filter = filters.filter_wait_on_queues('50')


### PR DESCRIPTION
You are probably much more interested in knowing which log lines had to wait _at least X milliseconds_ on HAProxy queues, rather than the other way around.

This way you can easily answer:

- how many requests had to wait more than 5 seconds in HAProxy?